### PR TITLE
Fix minor issue with missing stack push in ELC

### DIFF
--- a/src/NWNX/ELC.cs
+++ b/src/NWNX/ELC.cs
@@ -50,6 +50,7 @@ namespace NWN.NWNX
         public static void SetValidationFailureMessageStrRef(int strRef)
         {
             Internal.NativeFunctions.nwnxSetFunction(PLUGIN_NAME, "SetValidationFailureMessageStrRef");
+            Internal.NativeFunctions.nwnxPushInt(strRef);
             Internal.NativeFunctions.nwnxCallFunction();
         }
 


### PR DESCRIPTION
Fixed a bug where NWNX_ELC_SetValidationFailureMessageStrRef failed to push an int to the stack before being called.