### PR TITLE
Fix AC effect values

### DIFF
--- a/src/NWScript/Enums/AC.cs
+++ b/src/NWScript/Enums/AC.cs
@@ -1,0 +1,10 @@
+﻿namespace NWN.Enums {
+    public enum AC {
+        ArmorEnchantmentBonus = 2,
+        DeflectionBonus = 4,
+        DodgeBonus = 0,
+        NaturalBonus = 1,
+        ShieldEnchantmentBonus = 3,
+        VsDamageTypeAll = 4103
+    }
+}

--- a/src/NWScript/Functions/Effect.cs
+++ b/src/NWScript/Functions/Effect.cs
@@ -365,15 +365,17 @@ namespace NWN {
         ///   - nDamageType: DAMAGE_TYPE_*
         ///   * Default value for nDamageType should only ever be used in this function prototype.
         /// </summary>
-        public static Effect EffectACIncrease(int nValue,
-          ArmorClassModiferType nModifyType = ArmorClassModiferType.Dodge,
-          DamageType nDamageType = DamageType.Magical) {
+        public static Effect EffectACIncrease(
+            int nValue,
+            ArmorClassModiferType nModifyType = ArmorClassModiferType.Dodge,
+            AC nDamageType = AC.VsDamageTypeAll) {
             Internal.NativeFunctions.StackPushInteger((int)nDamageType);
             Internal.NativeFunctions.StackPushInteger((int)nModifyType);
             Internal.NativeFunctions.StackPushInteger(nValue);
             Internal.NativeFunctions.CallBuiltIn(115);
             return new Effect(Internal.NativeFunctions.StackPopEffect());
         }
+
 
         /// <summary>
         ///   Get the first in-game effect on oCreature.
@@ -906,9 +908,10 @@ namespace NWN {
         ///   - nDamageType: DAMAGE_TYPE_*
         ///   * Default value for nDamageType should only ever be used in this function prototype.
         /// </summary>
-        public static Effect EffectACDecrease(int nValue,
-          ArmorClassModiferType nModifyType = ArmorClassModiferType.Dodge,
-          DamageType nDamageType = DamageType.Magical) {
+        public static Effect EffectACDecrease(
+            int nValue,
+            ArmorClassModiferType nModifyType = ArmorClassModiferType.Dodge,
+            AC nDamageType = AC.VsDamageTypeAll) {
             Internal.NativeFunctions.StackPushInteger((int)nDamageType);
             Internal.NativeFunctions.StackPushInteger((int)nModifyType);
             Internal.NativeFunctions.StackPushInteger(nValue);


### PR DESCRIPTION
Create new AC enum and fix the ACIncrease / ACDecrease functions to use those instead of the DamageType. The comment from NWScript is misleading - these don't use DamageTypes, they use a different set of values for it.